### PR TITLE
Use raw input.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ TYPE_COMMENT = 8,
 TYPE_ELEMENT = 1;
 
 function hypertext(render, postprocess) {
-  return function(strings) {
+  return function({raw: strings}) {
     let state = STATE_DATA;
     let string = "";
     let nameStart;


### PR DESCRIPTION
Fixes #13. This isn’t backwards-compatible, so I’ll bump up 0.2.0.