### PR TITLE
rawtext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ function hypertext(render, postprocess) {
               const text = value + "";
               if (isEscapableRawText(tagName)) {
                 string += text.replace(/[<]/g, entity);
-              } else if (new RegExp(`</${tagName}[\\s>/]`, "i").test(text)) {
+              } else if (new RegExp(`</${tagName}[\\s>/]`, "i").test(string.slice(-tagName.length - 2) + text)) {
                 throw new Error("unsafe raw text"); // appropriate end tag
               } else {
                 string += text;

--- a/test/invalid-rawtext-test.js
+++ b/test/invalid-rawtext-test.js
@@ -3,6 +3,8 @@ import tape from "./jsdom.js";
 
 tape("interpolating a value with an appropriate end tag into raw text is not allowed", test => {
   test.throws(() => html`<script>${"</script>"}</script>`, Error);
+  test.throws(() => html`<script>${"</scr"}${"ipt  >"}</script>`, Error);
+  test.throws(() => html`<script></scr${"ipt  >"}</script>`, Error);
   test.throws(() => html`<script>${"</script foo>"}</script>`, Error);
   test.throws(() => html`<style>${"</style>"}</style>`, Error);
   test.throws(() => html`<style>${"</style foo>"}</style>`, Error);

--- a/test/invalid-rawtext-test.js
+++ b/test/invalid-rawtext-test.js
@@ -1,0 +1,9 @@
+import {html} from "htl";
+import tape from "./jsdom.js";
+
+tape("interpolating a value with an appropriate end tag into raw text is not allowed", test => {
+  test.throws(() => html`<script>${"</script>"}</script>`, Error);
+  test.throws(() => html`<script>${"</script foo>"}</script>`, Error);
+  test.throws(() => html`<style>${"</style>"}</style>`, Error);
+  test.throws(() => html`<style>${"</style foo>"}</style>`, Error);
+});

--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -33,33 +33,23 @@ export function interpolatedNumber() {
 }
 
 export function interpolateIntoRawText() {
-  // TODO https://github.com/observablehq/htl/issues/6
-  // return html`<style>p { background-image: url(${"foo.png?bar=1&baz=2"}); }</style>`;
-  return html`<style>p { background-image: url(foo.png?bar=1&baz=2); }</style>`;
+  return html`<style>p { background-image: url(${"foo.png?bar=1&baz=2"}); }</style>`;
 }
 
 export function interpolateIntoScript() {
-  // TODO https://github.com/observablehq/htl/issues/6
-  // return html`<script>${"value"}</script>`;
-  return html`<script>value</script>`;
+  return html`<script>${"value"}</script>`;
 }
 
 export function interpolateIntoStyle() {
-  // TODO https://github.com/observablehq/htl/issues/6
-  // return html`<style>${"value"}</style>`;
-  return html`<style>value</style>`;
+  return html`<style>${"value"}</style>`;
 }
 
 export function interpolateIntoTextarea() {
-  // TODO https://github.com/observablehq/htl/issues/18
-  // return html`<textarea>${"value"}</textarea>`;
-  return html`<textarea>value</textarea>`;
+  return html`<textarea>${"value"}</textarea>`;
 }
 
 export function interpolateIntoTitle() {
-  // TODO https://github.com/observablehq/htl/issues/18
-  // return html`<title>${"value"}</title>`;
-  return html`<title>value</title>`;
+  return html`<title>${"value"}</title>`;
 }
 
 export function interpolatedStyleObject() {

--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -40,6 +40,10 @@ export function interpolateIntoScript() {
   return html`<script>${"value"}</script>`;
 }
 
+export function interpolateIntoRawTextWithNonmatchingEndTag() {
+  return html`<script></style>${"value"}</script>`;
+}
+
 export function escapeIntoRawText() {
   return html`<script>${"1 < 2"}</script>`;
 }

--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -40,6 +40,14 @@ export function interpolateIntoScript() {
   return html`<script>${"value"}</script>`;
 }
 
+export function escapeIntoRawText() {
+  return html`<script>${"1 < 2"}</script>`;
+}
+
+export function escapeNonmatchingEndTagIntoRawText() {
+  return html`<script>${"</style>"}</script>`;
+}
+
 export function interpolateIntoStyle() {
   return html`<style>${"value"}</style>`;
 }

--- a/test/snapshots/escapeIntoRawText.html
+++ b/test/snapshots/escapeIntoRawText.html
@@ -1,0 +1,3 @@
+<script>
+  1 < 2
+</script>

--- a/test/snapshots/escapeNonmatchingEndTagIntoRawText.html
+++ b/test/snapshots/escapeNonmatchingEndTagIntoRawText.html
@@ -1,0 +1,3 @@
+<script>
+  < /style>
+</script>

--- a/test/snapshots/interpolateIntoRawTextWithNonmatchingEndTag.html
+++ b/test/snapshots/interpolateIntoRawTextWithNonmatchingEndTag.html
@@ -1,0 +1,3 @@
+<script>
+  < /style>value
+</script>

--- a/test/snapshots/interpolateIntoTextareaWithAttributes.html
+++ b/test/snapshots/interpolateIntoTextareaWithAttributes.html
@@ -1,0 +1,1 @@
+<textarea rows="1">value</textarea>


### PR DESCRIPTION
Fixes #6.
Fixes #18.
Fixes #21.

Note that there’s no way to safely interpolate a value such as `"</script>"` into a script element (an “appropriate” end tag in a non-escapable raw text element), so this case now throws an error.

/cc @tomlarkworthy