### PR TITLE
add usage example with DOM API to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ Hypertext literal tolerates malformed input—per the HTML5 specification—but 
 html`<${"button"}>Does this work?</>` // Error: invalid binding
 ```
 
+### Use with DOM API
+
+You can put the element (or text node) produced from a literal directly into the DOM: 
+```js
+const subject = "world"
+document.body.appendChild(html`<h1>Hello, ${subject}!</h1>`)
+```
+
 ## How it works
 
 Under the hood, hypertext literal implements a subset of the [HTML5 tokenizer](https://html.spec.whatwg.org/multipage/parsing.html#tokenization) state machine. This allows it to distinguish between tags, attributes, and the like. And so wherever an embedded expression occurs, it can be interpreted correctly.

--- a/README.md
+++ b/README.md
@@ -194,10 +194,11 @@ html`<${"button"}>Does this work?</>` // Error: invalid binding
 
 ### Use with DOM API
 
-You can put the element (or text node) produced from a literal directly into the DOM: 
+You can put the element (or text node, or fragment) produced from a hypertext literal directly into the DOM:
+
 ```js
-const subject = "world"
-document.body.appendChild(html`<h1>Hello, ${subject}!</h1>`)
+const subject = "world";
+document.body.appendChild(html`<h1>Hello, ${subject}!</h1>`);
 ```
 
 ## How it works


### PR DESCRIPTION
After reading the docs, playing in Observable, I didn't fully understand how this worked. I think the tiny example included in the README.md in this pull request would have helped me. It shows that we just produce plain DOM elements.