### PR TITLE
Allow interpolating tag names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,6 +189,22 @@ function hypertext(render, postprocess) {
             }
             break;
           }
+          case STATE_TAG_OPEN: {
+            const text = `${value}`;
+            if (!isValidTagName(text)) throw new Error("invalid tag name");
+            string += text;
+            tagName = text.toLowerCase();
+            state = STATE_BEFORE_ATTRIBUTE_NAME;
+            break;
+          }
+          case STATE_END_TAG_OPEN: {
+            const text = `${value}`;
+            if (!isValidTagName(text)) throw new Error("invalid tag name");
+            string += text;
+            tagName = text.toLowerCase();
+            state = STATE_BEFORE_ATTRIBUTE_NAME;
+            break;
+          }
           case STATE_DATA: {
             if (value == null) {
               // ignore
@@ -622,6 +638,10 @@ function isSpaceCode(code) {
       || code === CODE_FF
       || code === CODE_SPACE
       || code === CODE_CR; // normalize newlines
+}
+
+function isValidTagName(name) {
+  return /^[a-zA-Z][a-zA-Z0-9-]*$/.test(name);
 }
 
 function isObjectLiteral(value) {


### PR DESCRIPTION
This PR permits the following interpolation:

```js
html`<${tag}></${tag}>`
```

This is helpful for dynamic custom element redefinition (you cannot redefine custom elements, but you can version by tag name, and this change allows using that pattern much more easily in Observable notebooks). 

This is a proof of concept. If there's interest in getting this merged I can verify that the change is spec-compliant and add tests; I think I asked about this a few years ago and it wasn't in scope at the time.